### PR TITLE
Changes Promise.run to run in order placed in queue

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ PromiseMock.run = function run(count) {
 	}
 
 	while(runTimes > 0 && PromiseMock.waiting.length > 0) {
-		PromiseMock.waiting.pop()();
+		PromiseMock.waiting.shift()();
 		runTimes--;
 	}
 };

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -75,7 +75,7 @@ describe('Promise mock', function() {
 			Promise.reject().catch(function() {
 				done = true;
 			});
-			Promise.run();
+			Promise.run(2);
 			expect(done).toBe(true);
 		});
 		it('multiple runs', function() {
@@ -95,7 +95,7 @@ describe('Promise mock', function() {
 			}).catch(function() {
 				done = true;
 			});
-			Promise.run();
+			Promise.run(2);
 			expect(done).toBe(false);
 			Promise.run();
 			expect(done).toBe(true);
@@ -106,7 +106,7 @@ describe('Promise mock', function() {
 			}).then(function() {
 				done = true;
 			});
-			Promise.run();
+			Promise.run(2);
 			expect(done).toBe(false);
 			Promise.run();
 			expect(done).toBe(true);
@@ -119,7 +119,7 @@ describe('Promise mock', function() {
 			}).then(function() {
 				done = false;
 			});
-			Promise.run();
+			Promise.run(2);
 			expect(done).toBe(false);
 			Promise.run();
 			expect(done).toBe(true);


### PR DESCRIPTION
Currently whenever there is a promise waiting, they are pushed into PromiseMock.waiting, but run pops the last element and runs it synchronously. I want it to run the promises in the order they were placed so I am changing it to use shift in the run function.