### PR TITLE
Pin promise-polyfill to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "promises-aplus"
   ],
   "dependencies": {
-    "promise-polyfill": "*"
+    "promise-polyfill": "7.0.0"
   }
 }


### PR DESCRIPTION
We recently had a strange bug appear in CI, where our yarn.lock drifted away from what would be generated directly from package.json. The only tests that would break were our websocket ones that make extensive use of this library. We would get `No Promises waiting. Can't Promise.run()` errors thrown in each one.

My rough understanding of what was happening now is that because we had `promise-polyfill@7.0.0` installed in our main codebase, and also `promise-polyfill@*`, thanks to it being a dependency of this library. So we had two promise-polyfills in our yarn.lock:

```
promise-polyfill@*:
  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.1.0.tgz"
promise-polyfill@7.0.0:
  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.0.0.tgz"
```

It seems that was the root of the issue. I have to assume this is because there were two different versions of something that clobbers global variables, but I have to admit I haven't dived that deeply since my number one priority is to unblock our CI pipeline!

I've put in a PR here to pin the version but I'm happy to discuss other solutions. I mostly want to flag that this is an issue. My quick fix was actually to bump the version of promise-polyfill that we use in our main codebase to 7.1.0, since that's currently what `*` resolves to, but that is obviously not a permanent fix.